### PR TITLE
Fix support for future MediaWiki versions

### DIFF
--- a/Pure.skin.php
+++ b/Pure.skin.php
@@ -11,12 +11,9 @@ class SkinPure extends SkinTemplate {
 		$out->addModules( 'skins.pure.js' );
 
 		$out->addHtmlClasses('no-js');
-	}
-
-	function setupSkinUserCss( OutputPage $out ) {
-		parent::setupSkinUserCss( $out );
 		$out->addModuleStyles( array(
-			'mediawiki.skinning.interface', 'skins.pure.styles'
+			'mediawiki.skinning.interface',
+			'skins.pure.styles'
 		) );
 	}
 }

--- a/Pure.template.php
+++ b/Pure.template.php
@@ -2,6 +2,18 @@
 
 class PureTemplate extends BaseTemplate
 {
+	private function getPureFooterIcons() {
+		$footericons = $this->get('footericons');
+		foreach ( $footericons as $footerIconsKey => &$footerIconsBlock ) {
+			foreach ( $footerIconsBlock as $footerIconKey => $footerIcon ) {
+				if ( !isset( $footerIcon['src'] ) ) {
+					unset( $footerIconsBlock[$footerIconKey] );
+				}
+			}
+		}
+		return $footericons;
+	}
+
 	public function execute()
 	{
 		global $wgUser;

--- a/partial/Footer.php
+++ b/partial/Footer.php
@@ -10,7 +10,7 @@
         <?php } ?>
 
         <div class="columns is-justify-content-center">
-            <?php foreach ($this->getFooterIcons('icononly') as $blockName => $footerIcons) { ?>
+            <?php foreach ($this->getPureFooterIcons() as $blockName => $footerIcons) { ?>
                 <div class="column is-1">
                     <?php
                     foreach ($footerIcons as $icon) {

--- a/partial/Nav.php
+++ b/partial/Nav.php
@@ -53,7 +53,7 @@
                 <div class="navbar-item has-dropdown is-hoverable">
                     <a class="navbar-link"><i class="fa fa-cogs"></i></a>
                     <div class="navbar-dropdown is-right">
-                        <?php foreach ($this->getToolbox() as $key => $item) {
+                        <?php foreach ($this->data['sidebar']['TOOLBOX'] as $key => $item) {
                             echo $this->makeLink($key, $item, array('link-class' => 'navbar-item'));
                         } ?>
                     </div>

--- a/skin.json
+++ b/skin.json
@@ -8,6 +8,7 @@
     "requires": {
 		"MediaWiki": ">= 1.35.0"
 	},
+	"manifest_version": 2,
 	"type": "skin",
 	"ValidSkinNames": {
 		"pure": "Pure"


### PR DESCRIPTION
These methods will soon be removed from MediaWiki
or have already been moved from the current version
of MediaWiki. These should all be backwards compatible changes.

See:
https://phabricator.wikimedia.org/T279390
https://phabricator.wikimedia.org/T280610
https://phabricator.wikimedia.org/T278266