### PR TITLE
Fix Pure for MediaWiki 1.39

### DIFF
--- a/partial/Content.php
+++ b/partial/Content.php
@@ -1,7 +1,7 @@
 <div class="container mw-body p-4 is-max-desktop" id="content">
-<video autoplay muted loop id="myVideo">
-  <source src="<?php echo htmlspecialchars( $this->getSkin()->getSkinStylePath( 'assets/images/hacker.mp4' ) ) ?>" type="video/mp4">
-</video>
+    <video autoplay muted loop id="myVideo">
+        <source src="<?php echo $this->getSkin()->getConfig()->get( 'StylePath' ) . htmlspecialchars( '/Pure/assets/images/hacker.mp4' ) ?>" type="video/mp4">
+    </video>
     <div class="columns mt-2 mw-title">
         <div class="column is-full">
             <h1 class="title"><?php $this->html('title'); ?></h1>
@@ -16,10 +16,7 @@
     <div class="columns" id="bodyContent">
         <div class="column is-full" id="bodyContent">
             <?php
-            ob_start();
             $this->html('bodytext');
-            $out = ob_get_contents();
-            ob_end_clean();
             $markers = array("<h1", "<h2", "<h3");
             $tags = array('<h1 class="title is-4"', '<h2 class="title is-5"', '<h3 class="title is-6"');
             $body = str_replace($markers, $tags, $out);

--- a/partial/Nav.php
+++ b/partial/Nav.php
@@ -62,8 +62,11 @@
                     <a class="navbar-link"><i class="fa fa-user"></i></a>
                     <div class="navbar-dropdown is-right">
                         <?php foreach ($this->getPersonalTools() as $key => $item) {
-                            foreach ($item['links'] as $linkKey => $link) {
-                                echo $this->makeLink($linkKey, $link, array('link-class' => 'navbar-item'));
+                            foreach ($item['links'] ?? [] as $linkKey => $link) {
+                                $href = $link['href'] ?? null;
+                                if ( $href ) {
+                                    echo $this->makeLink($linkKey, $link, array('link-class' => 'navbar-item'));
+                                }
                             }
                         } ?>
                     </div>


### PR DESCRIPTION
* getSkinStylePath has been removed
* Modify Nav logic for the items which do not have an href
(These changes should also be backwards compatible)
